### PR TITLE
[Feature] Theme Overhaul -  Implement Salaryman theme and RatioDivider

### DIFF
--- a/src/components/common/AnimatedLink.astro
+++ b/src/components/common/AnimatedLink.astro
@@ -1,7 +1,7 @@
 ---
 interface Props {
-	href: string
-	text: string
+  href: string
+  text: string
 }
 
 const { href, text } = Astro.props
@@ -35,5 +35,5 @@ const letters = text.split('')
     ))}
   </span>
   
-  <span class="absolute bottom-0 left-0 w-full h-[1px] bg-border transition-colors duration-normal ease-smooth group-hover:bg-text-primary"></span>
+  <span class="absolute bottom-0 left-0 w-full h-[1px] bg-border transition-colors duration-normal ease-smooth group-hover:bg-accent"></span>
 </a>

--- a/src/components/common/Logo.astro
+++ b/src/components/common/Logo.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+  class?: string;
+}
+
+const { class: className = "w-8 h-8 md:w-10 md:h-10" } = Astro.props;
+---
+
+<svg 
+  xmlns="http://www.w3.org/2000/svg" 
+  viewBox="0 0 128 128" 
+  class={className}
+>
+  <path d="M16 24h20v34l24-34h24L52 64l32 40H60L36 70v34H16Z" fill="currentColor"/>
+  <path d="M112 24H64v20h28v20H64v40h48V84H84V64h28Z" fill="currentColor"/>
+</svg>

--- a/src/components/common/RatioDivider.astro
+++ b/src/components/common/RatioDivider.astro
@@ -1,0 +1,25 @@
+---
+interface Props {
+  class?: string;
+}
+
+const { class: className = "" } = Astro.props;
+---
+
+<svg class={className} viewBox="0 0 680 120" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="miter">
+  <title>Nanami 7:3 Ratio</title>
+  
+  <line x1="40" y1="60" x2="640" y2="60" stroke-width="5" />
+  <line x1="40" y1="38" x2="40" y2="82" stroke-width="6" />
+  <line x1="640" y1="38" x2="640" y2="82" stroke-width="6" />
+
+  <line x1="100" y1="43" x2="100" y2="77" stroke-width="4.5" />
+  <line x1="160" y1="43" x2="160" y2="77" stroke-width="4.5" />
+  <line x1="220" y1="43" x2="220" y2="77" stroke-width="4.5" />
+  <line x1="280" y1="43" x2="280" y2="77" stroke-width="4.5" />
+  <line x1="340" y1="43" x2="340" y2="77" stroke-width="4.5" />
+  <line x1="400" y1="43" x2="400" y2="77" stroke-width="4.5" />
+  
+  <line x1="520" y1="43" x2="520" y2="77" stroke-width="4.5" />
+  <line x1="580" y1="43" x2="580" y2="77" stroke-width="4.5" />
+</svg>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,21 +1,22 @@
 ---
 import { Clock } from '@/components/common/Clock'
+import Logo from '@/components/common/Logo.astro'
 import { COMMON_TEXT } from '@/const/common'
 
 const currentPath = Astro.url.pathname
 
 const navItems = [
-	{ href: '/work', label: COMMON_TEXT.NAVIGATION.WORK },
-	{ href: '/about', label: COMMON_TEXT.NAVIGATION.ABOUT },
-	{ href: '/contact', label: COMMON_TEXT.NAVIGATION.CONTACT },
+  { href: '/work', label: COMMON_TEXT.NAVIGATION.WORK },
+  { href: '/about', label: COMMON_TEXT.NAVIGATION.ABOUT },
+  { href: '/contact', label: COMMON_TEXT.NAVIGATION.CONTACT },
 ]
 ---
 
-<header class="flex justify-between items-center py-10 px-6 md:px-12 lg:px-16 w-full">
+<header class="flex justify-between items-center py-10 px-6 md:px-12 lg:px-16 w-full0">
   
   <div class="flex items-center gap-8 md:gap-12">
-    <a href="/" class="flex-shrink-0">
-      <img src="/favicon.svg" alt="Andrii" class="h-8 md:h-10 w-auto" />
+    <a href="/" class="flex-shrink-0 text-text-primary hover:text-accent transition-colors duration-fast ease-smooth" aria-label="Home">
+      <Logo class="h-10 md:h-12" />
     </a>
     
     <nav class="flex gap-4 md:gap-8 text-sm font-medium text-text-primary">
@@ -26,8 +27,8 @@ const navItems = [
           <a 
             href={item.href} 
             class:list={[
-              "p-1 transition-colors duration-fast ease-smooth hover:bg-text-muted",
-              { "bg-text-muted": isActive } 
+              "p-1 transition-colors duration-fast ease-smooth hover:text-accent",
+              { "text-accent": isActive } 
             ]}
           >
             {item.label}
@@ -37,7 +38,8 @@ const navItems = [
     </nav>
   </div>
 
-  <div class="hidden sm:block"> <Clock client:only="react" />
+  <div class="hidden sm:flex items-center gap-6">
+    <Clock client:only="react" />
   </div>
 
 </header>

--- a/src/components/pages/about/AboutDetails.astro
+++ b/src/components/pages/about/AboutDetails.astro
@@ -1,20 +1,30 @@
 ---
 import { ABOUT_TEXT } from '@/const/about'
+import RatioDivider from '@/components/common/RatioDivider.astro'
 ---
 <section class="mt-24 xl:mt-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-12 gap-10 xl:gap-8 items-start text-sm md:text-base font-body text-text-secondary">
   
-  <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8">
-    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-2">{ABOUT_TEXT.SECTIONS.BACKGROUND.TITLE}</h2>
+  <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8 group">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-accent transition-colors duration-normal mb-2">
+      <RatioDivider />
+    </div>
+    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.BACKGROUND.TITLE}</h2>
     <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.BACKGROUND.DESCRIPTION}</p>
   </div>
 
-  <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8">
-    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-2">{ABOUT_TEXT.SECTIONS.WORKFLOW.TITLE}</h2>
+  <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8 group">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-accent transition-colors duration-normal mb-2">
+      <RatioDivider />
+    </div>
+    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.WORKFLOW.TITLE}</h2>
     <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.WORKFLOW.DESCRIPTION}</p>
   </div>
 
-  <div class="xl:col-span-4 flex flex-col gap-3 xl:pl-12">
-    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-2">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.TITLE}</h2>
+  <div class="xl:col-span-4 flex flex-col gap-3 xl:pl-12 group">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-accent transition-colors duration-normal mb-2">
+      <RatioDivider />
+    </div>
+    <h2 class="text-text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.TITLE}</h2>
     <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.DESCRIPTION}</p>
   </div>
 

--- a/src/components/pages/home/TechArchive.astro
+++ b/src/components/pages/home/TechArchive.astro
@@ -15,7 +15,7 @@ import { HOME_TEXT } from '@/const/home'
   <div class="xl:col-span-4 flex flex-col font-mono text-xs tracking-wide xl:justify-self-end mt-4 xl:mt-0">
     <div class="grid grid-cols-[2rem_2.5rem_1fr] gap-x-1 gap-y-1.5 w-max">
       
-      <div class="text-text-primary">SV.</div>
+      <div class="text-text-primary font-semibold">SV.</div>
       <div class="text-text-primary">009</div>
       <div class="text-text-secondary">C#</div>
       
@@ -23,7 +23,7 @@ import { HOME_TEXT } from '@/const/home'
       <div class="text-text-primary">022</div>
       <div class="text-text-secondary">Node.js</div>
 
-      <div class="text-text-primary mt-3">UI.</div>
+      <div class="text-text-primary font-semibold mt-3">UI.</div>
       <div class="text-text-primary mt-3">300</div>
       <div class="text-text-secondary mt-3">React</div>
       
@@ -35,7 +35,7 @@ import { HOME_TEXT } from '@/const/home'
       <div class="text-text-primary">004</div>
       <div class="text-text-secondary">TailwindCSS</div>
 
-      <div class="text-text-primary mt-3">DT.</div>
+      <div class="text-text-primary font-semibold mt-3">DT.</div>
       <div class="text-text-primary mt-3">543</div>
       <div class="text-text-secondary mt-3">PostgreSQL</div>
       
@@ -43,7 +43,7 @@ import { HOME_TEXT } from '@/const/home'
       <div class="text-text-primary">330</div>
       <div class="text-text-secondary">MySQL</div>
       
-      <div class="text-text-primary mt-3">TL.</div>
+      <div class="text-text-primary font-semibold mt-3">TL.</div>
       <div class="text-text-primary mt-3">001</div>
       <div class="text-text-secondary mt-3">Git</div>
       

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -42,7 +42,8 @@ const projectImages = [soliloquyImg, cinemafrontImg, cinemadocsImg]
             class="w-full h-full object-cover grayscale opacity-90 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-slow scale-100 group-hover:scale-[1.02]"
           />
         </a>
-        <div class="custom-cursor pointer-events-none absolute top-0 left-0 z-50 flex items-center justify-center w-15 h-15 rounded-full bg-bg-base text-text-primary font-mono text-xs font-bold uppercase tracking-widest opacity-0 scale-50 transition-all duration-fast ease-smooth group-hover:opacity-100 group-hover:scale-100">
+        
+        <div class="custom-cursor pointer-events-none absolute top-0 left-0 z-50 flex items-center justify-center w-15 h-15 rounded-full bg-accent text-bg-base font-mono text-xs font-bold uppercase tracking-widest opacity-0 scale-50 transition-all duration-fast ease-smooth group-hover:opacity-100 group-hover:scale-100">
           {COMMON_TEXT.COMPONENTS.CURSOR_REPO}
         </div>
       </div>

--- a/src/styles/theme/colors.css
+++ b/src/styles/theme/colors.css
@@ -1,16 +1,16 @@
 @theme {
-  --color-bg-base: #fafaf7;
-  --color-bg-subtle: #f2f2ee;
-  --color-bg-muted: #e8e8e3;
+  --color-bg-base: #f7f7f5;
+  --color-bg-subtle: #efefea;
+  --color-bg-muted: #e6e6df;
 
-  --color-text-primary: #111110;
-  --color-text-secondary: #6b6b63;
-  --color-text-muted: #a8a89e;
+  --color-text-primary: #151514;
+  --color-text-secondary: #63635e;
+  --color-text-muted: #9e9e96;
 
-  --color-accent: #efe600;
-  --color-accent-hover: #d4cc00;
-  --color-accent-subtle: #fbf89a;
+  --color-accent: #06b6d4;
+  --color-accent-hover: #0891b2;
+  --color-accent-subtle: #cffafe;
 
-  --color-border: #e2e2dc;
-  --color-border-strong: #c8c8c0;
+  --color-border: #dcdcd6;
+  --color-border-strong: #c2c2bc;
 }


### PR DESCRIPTION
## Description
This PR transitions the portfolio's color palette to the new "Salaryman" aesthetic and introduces a subtle easter egg in the header.

## Changes Proposed
* **Theme Update:** Replaced default greys with warm beige/paper tones (`bg-base: #f7f7f5`) and set accent colors to cyan (`#06b6d4`) in `colors.css`.
* **Typography:** Kept the `::selection` background strictly black to preserve the brutalist "marker" highlight effect.
* **New Component:** Added `src/components/common/RatioDivider.astro` featuring an SVG line segmented at the 7:3 ratio.