### PR TITLE
feat: create /other-works page for secondary repositories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,8 @@
         "@astrojs/sitemap": "^3.7.2",
         "@fontsource-variable/unbounded": "^5.2.8",
         "@fontsource/arimo": "^5.2.8",
+        "@fontsource/shippori-mincho": "^5.2.8",
+        "@fontsource/space-mono": "^5.2.9",
         "@tailwindcss/vite": "^4.2.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -221,6 +223,10 @@
     "@fontsource-variable/unbounded": ["@fontsource-variable/unbounded@5.2.8", "", {}, "sha512-DWC/HEdNNbjMH6ngeeCAPExKMsedoY+pV3ZnRXzFcAzXuGHB6dEwsXNVQ4fiuuYMGguq9TSAEUat4Oy5prdwWQ=="],
 
     "@fontsource/arimo": ["@fontsource/arimo@5.2.8", "", {}, "sha512-EGB/l4PhYsxJbskePrgFQKM3Ob+x3Xr+VZDuSMR2XNVQYhx8t5zIfiMxCLLbgBPkY2qeXGfbyrXeAOEGl1lOSA=="],
+
+    "@fontsource/shippori-mincho": ["@fontsource/shippori-mincho@5.2.8", "", {}, "sha512-GoWDgrzVyB1oUufPKN9suBaM+TpliiBcMwEalqqMeO38xdGJzY/ZwhehZsxyOoR56c1l98vwXbj+tXWHyGefJA=="],
+
+    "@fontsource/space-mono": ["@fontsource/space-mono@5.2.9", "", {}, "sha512-b61faFOHEISQ/pD25G+cfGY9o/WW6lRv6hBQQfpWvEJ4y1V+S4gmth95EVyBE2VL3qDYHeVQ8nBzrplzdXTDDg=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -4,3 +4,5 @@
 declare module '@fontsource-variable/unbounded'
 declare module '@fontsource/arimo'
 declare module '@fontsource-variable/arimo'
+declare module '@fontsource/shippori-mincho'
+declare module '@fontsource/space-mono'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"@astrojs/sitemap": "^3.7.2",
 		"@fontsource-variable/unbounded": "^5.2.8",
 		"@fontsource/arimo": "^5.2.8",
+		"@fontsource/shippori-mincho": "^5.2.8",
+		"@fontsource/space-mono": "^5.2.9",
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",

--- a/src/components/pages/other-works/MangaPanel.astro
+++ b/src/components/pages/other-works/MangaPanel.astro
@@ -1,0 +1,42 @@
+---
+import type { Project } from '@/const/other-works'
+
+interface Props {
+	project: Project
+}
+
+const { project } = Astro.props
+
+const spanClasses = {
+	small: 'col-span-1 md:col-span-1',
+	wide: 'col-span-1 md:col-span-2',
+	large: 'col-span-1 md:col-span-3',
+}
+
+const panelClass = spanClasses[project.panelSize || 'small']
+---
+
+<a 
+  href={project.link} 
+  target="_blank" 
+  rel="noopener noreferrer" 
+  class={`group flex flex-col border-[6px] border-primary p-6 md:p-8 hover:bg-primary hover:text-basic transition-none ${panelClass}`}
+>
+  <div class="flex justify-between items-start mb-12 md:mb-24 gap-4">
+    <span class="font-mono text-sm md:text-base font-bold opacity-50 group-hover:opacity-100 transition-none shrink-0">
+      #{project.id}
+    </span>
+    <span class="font-mono text-xs uppercase tracking-widest border-2 border-primary px-3 py-1 group-hover:border-basic group-hover:text-basic transition-none text-right">
+      {project.tech}
+    </span>
+  </div>
+
+  <div class="mt-auto">
+    <h3 class="font-heading text-4xl md:text-6xl font-black mb-4 uppercase tracking-tighter leading-[0.9] group-hover:text-basic transition-none">
+      {project.title}
+    </h3>
+    <p class="font-mono text-sm md:text-base leading-relaxed opacity-80 group-hover:opacity-100 transition-none">
+      {project.description}
+    </p>
+  </div>
+</a>

--- a/src/components/pages/other-works/MangaPanel.astro
+++ b/src/components/pages/other-works/MangaPanel.astro
@@ -1,5 +1,5 @@
 ---
-import type { Project } from '@/const/other-works'
+import { OTHER_WORKS, type Project } from '@/const/other-works'
 
 interface Props {
 	project: Project
@@ -24,7 +24,7 @@ const panelClass = spanClasses[project.panelSize || 'small']
 >
   <div class="flex justify-between items-start mb-12 md:mb-24 gap-4">
     <span class="font-mono text-sm md:text-base font-bold opacity-50 group-hover:opacity-100 transition-none shrink-0">
-      #{project.id}
+      {OTHER_WORKS.DECORATION.ID_PREFIX}{project.id}
     </span>
     <span class="font-mono text-xs uppercase tracking-widest border-2 border-primary px-3 py-1 group-hover:border-basic group-hover:text-basic transition-none text-right">
       {project.tech}

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -57,9 +57,14 @@ const projectImages = [
           {COMMON_TEXT.COMPONENTS.CURSOR_REPO}
         </div>
       </div>
-
     </section>
   ))}
+  <section class="flex flex-col items-center justify-center text-center mt-12 md:mt-32 pb-24 border-t border-border pt-24">
+    <h3 class="text-secondary font-mono text-xs uppercase tracking-widest mb-6">
+      {WORK_TEXT.FOOTER.TITLE}
+    </h3>
+    <AnimatedLink href="/other-works" text={WORK_TEXT.FOOTER.LINK_TEXT} />
+  </section>
 </div>
 
 <script>

--- a/src/const/other-works.ts
+++ b/src/const/other-works.ts
@@ -1,0 +1,64 @@
+export interface Project {
+	id: string
+	title: string
+	description: string
+	tech: string
+	link: string
+	panelSize?: 'small' | 'wide' | 'large'
+}
+
+export const PROJECTS: Project[] = [
+	{
+		id: '001',
+		title: 'StackFetch',
+		description:
+			'CLI that displays essential information about your current working directory.',
+		tech: 'TypeScript, Shell',
+		link: 'https://github.com/stkossman/StackFetch',
+		panelSize: 'large',
+	},
+	{
+		id: '002',
+		title: 'Toji Fushiguro Theme',
+		description: 'VS Code theme inspired by Toji Fushiguro.',
+		tech: 'CSS',
+		link: 'https://github.com/stkossman/toji-fushiguro-theme',
+		panelSize: 'small',
+	},
+	{
+		id: '003',
+		title: 'Abysswalker Theme',
+		description: 'A minimal, dark fantasy inspired VS Code theme.',
+		tech: 'CSS',
+		link: 'https://github.com/stkossman/abysswalker-theme',
+		panelSize: 'wide',
+	},
+	{
+		id: '004',
+		title: 'Frameworks Mini Project',
+		description:
+			'A comprehensive collection of mini-projects built with minimalist frameworks.',
+		tech: 'VanJS, htmx, Alpine.js, Stimulus',
+		link: 'https://github.com/stkossman/frameworks-mini-project',
+		panelSize: 'large',
+	},
+	{
+		id: '005',
+		title: 'Ukraine Phone Formatter',
+		description:
+			'Ukraine Phone Formatter is a simple Ruby gem that formats Ukrainian phone numbers into a readable and standardized format.',
+		tech: 'Ruby',
+		link: 'https://github.com/stkossman/ukraine_phone_formatter',
+		panelSize: 'large',
+	},
+]
+
+export const OTHER_WORKS = {
+	HERO: {
+		TITLE: 'ARCHIVE',
+		DESCRIPTION: 'Secondary repositories. Experimental tools.',
+	},
+	BUTTON: {
+		TEXT: '[ Return to Main ]',
+	},
+}

--- a/src/const/other-works.ts
+++ b/src/const/other-works.ts
@@ -54,9 +54,16 @@ export const PROJECTS: Project[] = [
 ]
 
 export const OTHER_WORKS = {
+	METADATA: {
+		TITLE: 'Archive — Andri Stavskyi',
+	},
 	HERO: {
 		TITLE: 'ARCHIVE',
 		DESCRIPTION: 'Secondary repositories. Experimental tools.',
+		NUMBER: '02',
+	},
+	DECORATION: {
+		ID_PREFIX: '#',
 	},
 	BUTTON: {
 		TEXT: '[ Return to Main ]',

--- a/src/const/work.ts
+++ b/src/const/work.ts
@@ -57,4 +57,8 @@ export const WORK_TEXT = {
 			link: 'https://github.com/ModusTeam/cinema-platform-docs',
 		},
 	],
+	FOOTER: {
+		TITLE: 'Looking for experimental repositories?',
+		LINK_TEXT: '[ Access Arsenal ]',
+	},
 } as const

--- a/src/layouts/MangaLayout.astro
+++ b/src/layouts/MangaLayout.astro
@@ -25,7 +25,7 @@ const { title, description, image } = Astro.props
     <meta name="generator" content={Astro.generator} />
     <Seo title={title} description={description} image={image} />
   </head>
-  <body class="theme-manga bg-basic text-primary font-body antialiased selection:bg-primary selection:text-basic min-h-screen border-8 border-primary">
+  <body class="theme-manga bg-basic text-primary font-body antialiased min-h-screen border-8 border-primary">
     <main class="max-w-7xl mx-auto px-6 md:px-12 py-12">
       <slot />
     </main>

--- a/src/layouts/MangaLayout.astro
+++ b/src/layouts/MangaLayout.astro
@@ -1,0 +1,33 @@
+---
+import '@/styles/global.css'
+import '@/styles/theme/manga.css'
+
+import '@fontsource/shippori-mincho'
+import '@fontsource/space-mono'
+
+import Seo from '@/components/common/Seo.astro'
+
+interface Props {
+	title: string
+	description?: string
+	image?: string
+}
+
+const { title, description, image } = Astro.props
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="generator" content={Astro.generator} />
+    <Seo title={title} description={description} image={image} />
+  </head>
+  <body class="theme-manga bg-basic text-primary font-body antialiased selection:bg-primary selection:text-basic min-h-screen border-8 border-primary">
+    <main class="max-w-7xl mx-auto px-6 md:px-12 py-12">
+      <slot />
+    </main>
+  </body>
+</html>

--- a/src/pages/other-works.astro
+++ b/src/pages/other-works.astro
@@ -1,0 +1,34 @@
+---
+import MangaPanel from '@/components/pages/other-works/MangaPanel.astro'
+import { OTHER_WORKS, PROJECTS } from '@/const/other-works'
+import MangaLayout from '@/layouts/MangaLayout.astro'
+---
+
+<MangaLayout title="Arsenal — Andrii Stavskyi">
+  <header class="mb-12 md:mb-16 border-b-[12px] border-primary pb-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
+    <div>
+      <h1 class="font-heading text-6xl md:text-8xl lg:text-[10rem] font-black uppercase tracking-tighter leading-none mb-2 md:mb-4">
+        {OTHER_WORKS.HERO.TITLE}
+      </h1>
+      <p class="font-mono text-base md:text-lg max-w-xl opacity-80 uppercase tracking-widest">
+        {OTHER_WORKS.HERO.DESCRIPTION} <br class="hidden md:block" />
+      </p>
+    </div>
+    
+    <div class="hidden lg:block font-heading text-[8rem] font-black leading-none opacity-10">
+      02
+    </div>
+  </header>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 auto-rows-auto">
+    {PROJECTS.map(project => (
+      <MangaPanel project={project} />
+    ))}
+  </div>
+  
+  <footer class="mt-24 pt-8 border-t-4 border-primary text-center">
+    <a href="/" class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
+      {OTHER_WORKS.BUTTON.TEXT}
+    </a>
+  </footer>
+</MangaLayout>

--- a/src/pages/other-works.astro
+++ b/src/pages/other-works.astro
@@ -4,7 +4,7 @@ import { OTHER_WORKS, PROJECTS } from '@/const/other-works'
 import MangaLayout from '@/layouts/MangaLayout.astro'
 ---
 
-<MangaLayout title="Arsenal — Andrii Stavskyi">
+<MangaLayout title={OTHER_WORKS.METADATA.TITLE}>
   <header class="mb-12 md:mb-16 border-b-[12px] border-primary pb-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
     <div>
       <h1 class="font-heading text-6xl md:text-8xl lg:text-[10rem] font-black uppercase tracking-tighter leading-none mb-2 md:mb-4">
@@ -16,7 +16,7 @@ import MangaLayout from '@/layouts/MangaLayout.astro'
     </div>
     
     <div class="hidden lg:block font-heading text-[8rem] font-black leading-none opacity-10">
-      02
+      {OTHER_WORKS.HERO.NUMBER}
     </div>
   </header>
 

--- a/src/styles/theme/manga.css
+++ b/src/styles/theme/manga.css
@@ -1,0 +1,39 @@
+.theme-manga {
+  --color-basic: #ffffff;
+  --color-subtle: #f2f2f2;
+  --color-bg-muted: #e5e5e5;
+
+  --color-primary: #000000;
+  --color-secondary: #333333;
+  --color-secondary-hover: #000000;
+  --color-muted: #888888;
+
+  --color-accent: #000000; 
+  --color-accent-hover: #333333;
+  --color-accent-subtle: #cccccc;
+
+  --color-border: #000000; 
+  --color-border-strong: #000000;
+
+  --font-heading: 'Shippori Mincho', serif;
+  --font-body: 'Space Mono', monospace;
+  
+  --ease-smooth: cubic-bezier(0.1, 1, 0, 1);
+  --duration-normal: 100ms;
+}
+
+.theme-manga ::selection {
+  background-color: #000000;
+  color: #ffffff;
+}
+
+.theme-manga a {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 2px;
+}
+.theme-manga a:hover {
+  background-color: #000000;
+  color: #ffffff;
+  text-decoration-color: transparent;
+}


### PR DESCRIPTION
## What & Why
Introduced the `/other-works` (Arsenal) route to host secondary repositories. Isolated its brutalist, high-contrast aesthetic using a dedicated layout to maintain the main portfolio's zero-noise philosophy.

**Resolves:** #24 

---

## Changes
- Created `src/styles/theme/manga.css` and `MangaLayout.astro` for strict CSS scoping.
- Extracted data to `src/const/other-works.ts` to separate concerns.
- Implemented `MangaPanel.astro` and `/other-works` route using an asymmetric CSS Grid.
- Appended a discrete entry link at the end of `ProjectList.astro`.

---

## Visuals
N/A

---

## Checklist

- [x] Follows project architecture
- [x] UI stays minimal — no unnecessary noise
- [x] Tested locally (`bun run dev`)
- [ ] `bunx biome check` and `bunx astro check` pass