### PR TITLE
feat: architect the /archive hub for secondary projects and toolkit

### DIFF
--- a/src/components/pages/archive/MangaPanel.astro
+++ b/src/components/pages/archive/MangaPanel.astro
@@ -1,8 +1,8 @@
 ---
-import { OTHER_WORKS, type Project } from '@/const/other-works'
+import { ARSENAL_WORKS_TEXT, type ArsenalWork } from '@/const/archive/arsenal'
 
 interface Props {
-	project: Project
+	project: ArsenalWork
 }
 
 const { project } = Astro.props
@@ -24,7 +24,7 @@ const panelClass = spanClasses[project.panelSize || 'small']
 >
   <div class="flex justify-between items-start mb-12 md:mb-24 gap-4">
     <span class="font-mono text-sm md:text-base font-bold opacity-50 group-hover:opacity-100 transition-none shrink-0">
-      {OTHER_WORKS.DECORATION.ID_PREFIX}{project.id}
+      {ARSENAL_WORKS_TEXT.DECORATION.ID_PREFIX}{project.id}
     </span>
     <span class="font-mono text-xs uppercase tracking-widest border-2 border-primary px-3 py-1 group-hover:border-basic group-hover:text-basic transition-none text-right">
       {project.tech}

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -63,7 +63,7 @@ const projectImages = [
     <h3 class="text-secondary font-mono text-xs uppercase tracking-widest mb-6">
       {WORK_TEXT.FOOTER.TITLE}
     </h3>
-    <AnimatedLink href="/other-works" text={WORK_TEXT.FOOTER.LINK_TEXT} />
+    <AnimatedLink href="/archive" text={WORK_TEXT.FOOTER.LINK_TEXT} />
   </section>
 </div>
 

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -63,7 +63,7 @@ const projectImages = [
     <h3 class="text-secondary font-mono text-xs uppercase tracking-widest mb-6">
       {WORK_TEXT.FOOTER.TITLE}
     </h3>
-    <AnimatedLink href="/archive" text={WORK_TEXT.FOOTER.LINK_TEXT} />
+    <AnimatedLink href={WORK_TEXT.FOOTER.HREF} text={WORK_TEXT.FOOTER.LINK_TEXT} />
   </section>
 </div>
 

--- a/src/const/archive/arsenal.ts
+++ b/src/const/archive/arsenal.ts
@@ -55,7 +55,7 @@ export const ARSENAL_WORKS: ArsenalWork[] = [
 
 export const ARSENAL_WORKS_TEXT = {
 	METADATA: {
-		TITLE: 'Arsenal — Andri Stavskyi',
+		TITLE: 'Arsenal — Andrii Stavskyi',
 	},
 	HERO: {
 		TITLE: 'ARSENAL',
@@ -68,5 +68,6 @@ export const ARSENAL_WORKS_TEXT = {
 	},
 	BUTTON: {
 		TEXT: '[ Return to Hub ]',
+		HREF: '/archive',
 	},
 }

--- a/src/const/archive/arsenal.ts
+++ b/src/const/archive/arsenal.ts
@@ -1,4 +1,4 @@
-export interface Project {
+export interface ArsenalWork {
 	id: string
 	title: string
 	description: string
@@ -7,7 +7,7 @@ export interface Project {
 	panelSize?: 'small' | 'wide' | 'large'
 }
 
-export const PROJECTS: Project[] = [
+export const ARSENAL_WORKS: ArsenalWork[] = [
 	{
 		id: '001',
 		title: 'StackFetch',
@@ -21,7 +21,7 @@ export const PROJECTS: Project[] = [
 		id: '002',
 		title: 'Toji Fushiguro Theme',
 		description: 'VS Code theme inspired by Toji Fushiguro.',
-		tech: 'CSS',
+		tech: 'CSS, VS Code Extension API',
 		link: 'https://github.com/stkossman/toji-fushiguro-theme',
 		panelSize: 'small',
 	},
@@ -29,7 +29,7 @@ export const PROJECTS: Project[] = [
 		id: '003',
 		title: 'Abysswalker Theme',
 		description: 'A minimal, dark fantasy inspired VS Code theme.',
-		tech: 'CSS',
+		tech: 'CSS, VS Code Extension API',
 		link: 'https://github.com/stkossman/abysswalker-theme',
 		panelSize: 'wide',
 	},
@@ -53,13 +53,14 @@ export const PROJECTS: Project[] = [
 	},
 ]
 
-export const OTHER_WORKS = {
+export const ARSENAL_WORKS_TEXT = {
 	METADATA: {
-		TITLE: 'Archive — Andri Stavskyi',
+		TITLE: 'Arsenal — Andri Stavskyi',
 	},
 	HERO: {
-		TITLE: 'ARCHIVE',
-		DESCRIPTION: 'Secondary repositories. Experimental tools.',
+		TITLE: 'ARSENAL',
+		DESCRIPTION:
+			'A collection of my personal projects, tools, and experiments.',
 		NUMBER: '02',
 	},
 	DECORATION: {

--- a/src/const/archive/arsenal.ts
+++ b/src/const/archive/arsenal.ts
@@ -21,7 +21,7 @@ export const ARSENAL_WORKS: ArsenalWork[] = [
 		id: '002',
 		title: 'Toji Fushiguro Theme',
 		description: 'VS Code theme inspired by Toji Fushiguro.',
-		tech: 'CSS, VS Code Extension API',
+		tech: 'CSS',
 		link: 'https://github.com/stkossman/toji-fushiguro-theme',
 		panelSize: 'small',
 	},
@@ -29,7 +29,7 @@ export const ARSENAL_WORKS: ArsenalWork[] = [
 		id: '003',
 		title: 'Abysswalker Theme',
 		description: 'A minimal, dark fantasy inspired VS Code theme.',
-		tech: 'CSS, VS Code Extension API',
+		tech: 'CSS',
 		link: 'https://github.com/stkossman/abysswalker-theme',
 		panelSize: 'wide',
 	},
@@ -61,12 +61,12 @@ export const ARSENAL_WORKS_TEXT = {
 		TITLE: 'ARSENAL',
 		DESCRIPTION:
 			'A collection of my personal projects, tools, and experiments.',
-		NUMBER: '02',
+		NUMBER: '01',
 	},
 	DECORATION: {
 		ID_PREFIX: '#',
 	},
 	BUTTON: {
-		TEXT: '[ Return to Main ]',
+		TEXT: '[ Return to Hub ]',
 	},
 }

--- a/src/const/archive/hub.ts
+++ b/src/const/archive/hub.ts
@@ -1,0 +1,29 @@
+export const HUB_TEXT = {
+	METADATA: {
+		TITLE: 'Archive Hub — Andrii Stavskyi',
+	},
+	HERO: {
+		TITLE: 'THE ARCHIVE',
+		DESCRIPTION: 'Secondary repositories and operational toolkits.',
+		NUMBER: '00',
+	},
+	NAVIGATION: [
+		{
+			id: '01',
+			title: 'ARSENAL',
+			description:
+				'Secondary repositories, experimental tools, and archived projects.',
+			href: '/archive/arsenal',
+		},
+		{
+			id: '02',
+			title: 'USES',
+			description: 'Hardware, software, configurations, and AI.',
+			href: '/archive/uses',
+		},
+	],
+	BUTTON: {
+		TEXT: '[ Return to Main ]',
+		HREF: '/',
+	},
+}

--- a/src/const/archive/uses.ts
+++ b/src/const/archive/uses.ts
@@ -1,0 +1,69 @@
+export interface UseItem {
+	name: string
+	description: string
+}
+
+export interface UseCategory {
+	title: string
+	items: UseItem[]
+}
+
+export const USES_CATEGORIES: UseCategory[] = [
+	{
+		title: 'HARDWARE',
+		items: [
+			{
+				name: 'Primary Workstation',
+				description: 'HP Pavilion 15 (Ryzen 5 5600H, RTX 3050)',
+			},
+			{
+				name: 'Secondary Workstation',
+				description: 'Lenovo Legion (Intel i7-7700HQ, GTX 1050)',
+			},
+			{ name: 'Keyboard', description: 'Keychron V1 Wired' },
+			{ name: 'Mouse', description: 'Hator Pulsar 3' },
+		],
+	},
+	{
+		title: 'SYSTEM & ENVIRONMENT',
+		items: [
+			{ name: 'OS', description: 'Windows 11 / Fedora Linux' },
+			{ name: 'Window Manager', description: 'Hyprland' },
+			{ name: 'Terminal', description: 'Ghostty + Zsh' },
+		],
+	},
+	{
+		title: 'WORKSPACE & EDITOR',
+		items: [
+			{ name: 'Editor', description: 'VS Code / Zed' },
+			{ name: 'Theme', description: 'Toji Fushiguro Theme' },
+			{ name: 'Keyboard Layout', description: 'Qwerty / Colemak' },
+		],
+	},
+	{
+		title: 'SERVICES & TOOLS',
+		items: [
+			{
+				name: 'AI Subscriptions',
+				description: 'Gemini Pro, Perplexity Pro, GitHub Copilot',
+			},
+			{ name: 'Browser', description: 'Zen Browser' },
+		],
+	},
+]
+
+export const USES_TEXT = {
+	METADATA: {
+		TITLE: 'Uses — Andrii Stavskyi',
+	},
+	HERO: {
+		TITLE: 'USES',
+		DESCRIPTION:
+			'A technical manifest of operational hardware, software, and configurations.',
+		NUMBER: '02',
+	},
+	BUTTON: {
+		TEXT: '[ Return to Hub ]',
+		HREF: '/archive',
+	},
+}

--- a/src/const/work.ts
+++ b/src/const/work.ts
@@ -60,5 +60,6 @@ export const WORK_TEXT = {
 	FOOTER: {
 		TITLE: 'Looking for experimental repositories?',
 		LINK_TEXT: '[ Access Arsenal ]',
+		HREF: '/archive',
 	},
 } as const

--- a/src/pages/archive/arsenal.astro
+++ b/src/pages/archive/arsenal.astro
@@ -27,7 +27,7 @@ import MangaLayout from '@/layouts/MangaLayout.astro'
   </div>
   
   <footer class="mt-24 pt-8 border-t-4 border-primary text-center">
-    <a href="/archive" class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
+    <a href={ARSENAL_WORKS_TEXT.BUTTON.HREF} class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
       {ARSENAL_WORKS_TEXT.BUTTON.TEXT}
     </a>
   </footer>

--- a/src/pages/archive/arsenal.astro
+++ b/src/pages/archive/arsenal.astro
@@ -1,34 +1,34 @@
 ---
-import MangaPanel from '@/components/pages/other-works/MangaPanel.astro'
-import { OTHER_WORKS, PROJECTS } from '@/const/other-works'
+import MangaPanel from '@/components/pages/archive/MangaPanel.astro'
+import { ARSENAL_WORKS, ARSENAL_WORKS_TEXT } from '@/const/archive/arsenal'
 import MangaLayout from '@/layouts/MangaLayout.astro'
 ---
 
-<MangaLayout title={OTHER_WORKS.METADATA.TITLE}>
+<MangaLayout title={ARSENAL_WORKS_TEXT.METADATA.TITLE}>
   <header class="mb-12 md:mb-16 border-b-[12px] border-primary pb-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
     <div>
       <h1 class="font-heading text-6xl md:text-8xl lg:text-[10rem] font-black uppercase tracking-tighter leading-none mb-2 md:mb-4">
-        {OTHER_WORKS.HERO.TITLE}
+        {ARSENAL_WORKS_TEXT.HERO.TITLE}
       </h1>
       <p class="font-mono text-base md:text-lg max-w-xl opacity-80 uppercase tracking-widest">
-        {OTHER_WORKS.HERO.DESCRIPTION} <br class="hidden md:block" />
+        {ARSENAL_WORKS_TEXT.HERO.DESCRIPTION} <br class="hidden md:block" />
       </p>
     </div>
     
     <div class="hidden lg:block font-heading text-[8rem] font-black leading-none opacity-10">
-      {OTHER_WORKS.HERO.NUMBER}
+      {ARSENAL_WORKS_TEXT.HERO.NUMBER}
     </div>
   </header>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 auto-rows-auto">
-    {PROJECTS.map(project => (
+    {ARSENAL_WORKS.map(project => (
       <MangaPanel project={project} />
     ))}
   </div>
   
   <footer class="mt-24 pt-8 border-t-4 border-primary text-center">
-    <a href="/" class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
-      {OTHER_WORKS.BUTTON.TEXT}
+    <a href="/archive" class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
+      {ARSENAL_WORKS_TEXT.BUTTON.TEXT}
     </a>
   </footer>
 </MangaLayout>

--- a/src/pages/archive/index.astro
+++ b/src/pages/archive/index.astro
@@ -1,0 +1,48 @@
+---
+import { HUB_TEXT } from '@/const/archive/hub'
+import MangaLayout from '@/layouts/MangaLayout.astro'
+---
+
+<MangaLayout title={HUB_TEXT.METADATA.TITLE}>
+  <header class="mb-16 border-b-[12px] border-primary pb-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
+    <div>
+      <h1 class="font-heading text-6xl md:text-8xl lg:text-[10rem] font-black uppercase tracking-tighter leading-none mb-2 md:mb-4">
+        {HUB_TEXT.HERO.TITLE}
+      </h1>
+      <p class="font-mono text-base md:text-lg max-w-xl opacity-80 uppercase tracking-widest">
+        {HUB_TEXT.HERO.DESCRIPTION}
+      </p>
+    </div>
+    
+    <div class="hidden lg:block font-heading text-[8rem] font-black leading-none opacity-10">
+      {HUB_TEXT.HERO.NUMBER}
+    </div>
+  </header>
+
+  <nav class="flex flex-col border-t-[6px] border-primary">
+    {HUB_TEXT.NAVIGATION.map((item) => (
+      <a 
+        href={item.href}
+        class="group flex flex-col md:flex-row md:items-center justify-between border-b-[6px] border-primary p-6 md:p-12 hover:bg-primary hover:text-basic transition-none"
+      >
+        <div class="flex items-start md:items-center gap-6 md:gap-12 mb-4 md:mb-0">
+          <span class="font-mono text-2xl md:text-4xl font-bold opacity-50 group-hover:opacity-100 transition-none">
+            [{item.id}]
+          </span>
+          <h2 class="font-heading text-5xl md:text-7xl font-black uppercase tracking-tighter transition-none">
+            {item.title}
+          </h2>
+        </div>
+        <p class="font-mono text-sm md:text-base max-w-md text-left md:text-right opacity-80 group-hover:opacity-100 transition-none">
+          {item.description}
+        </p>
+      </a>
+    ))}
+  </nav>
+
+  <footer class="mt-24 pt-8 text-center">
+    <a href={HUB_TEXT.BUTTON.HREF} class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
+      {HUB_TEXT.BUTTON.TEXT}
+    </a>
+  </footer>
+</MangaLayout>

--- a/src/pages/archive/uses.astro
+++ b/src/pages/archive/uses.astro
@@ -1,0 +1,55 @@
+---
+import { USES_CATEGORIES, USES_TEXT } from '@/const/archive/uses'
+import MangaLayout from '@/layouts/MangaLayout.astro'
+---
+
+<MangaLayout title={USES_TEXT.METADATA.TITLE}>
+  <header class="mb-16 border-b-[12px] border-primary pb-8 flex flex-col md:flex-row md:items-end justify-between gap-6">
+    <div>
+      <h1 class="font-heading text-6xl md:text-8xl lg:text-[10rem] font-black uppercase tracking-tighter leading-none mb-2 md:mb-4">
+        {USES_TEXT.HERO.TITLE}
+      </h1>
+      <p class="font-mono text-base md:text-lg max-w-xl opacity-80 uppercase tracking-widest">
+        {USES_TEXT.HERO.DESCRIPTION}
+      </p>
+    </div>
+    
+    <div class="hidden lg:block font-heading text-[8rem] font-black leading-none opacity-10">
+      {USES_TEXT.HERO.NUMBER}
+    </div>
+  </header>
+
+  <div class="flex flex-col gap-16 md:gap-24">
+    {USES_CATEGORIES.map((category) => (
+      <section>
+        <h2 class="font-heading text-4xl md:text-5xl font-black uppercase tracking-tighter border-b-4 border-primary pb-4 mb-6">
+          {category.title}
+        </h2>
+        
+        <ul class="flex flex-col border-t-2 border-primary">
+          {category.items.map((item) => (
+            <li>
+              <div class="group flex items-end p-4 md:p-6 border-b-2 border-primary hover:bg-primary hover:text-basic transition-none cursor-crosshair">
+                <span class="font-mono text-base md:text-xl font-bold uppercase whitespace-nowrap transition-none">
+                  {item.name}
+                </span>
+                
+                <div class="dotted-leader"></div>
+                
+                <span class="font-mono text-sm md:text-lg opacity-80 text-right transition-none">
+                  {item.description}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+
+  <footer class="mt-24 pt-8 border-t-4 border-primary text-center">
+    <a href={USES_TEXT.BUTTON.HREF} class="font-mono text-sm uppercase tracking-widest font-bold hover:bg-primary hover:text-basic px-6 py-3 border-2 border-primary transition-none inline-block">
+      {USES_TEXT.BUTTON.TEXT}
+    </a>
+  </footer>
+</MangaLayout>

--- a/src/pages/archive/uses.astro
+++ b/src/pages/archive/uses.astro
@@ -28,18 +28,16 @@ import MangaLayout from '@/layouts/MangaLayout.astro'
         
         <ul class="flex flex-col border-t-2 border-primary">
           {category.items.map((item) => (
-            <li>
-              <div class="group flex items-end p-4 md:p-6 border-b-2 border-primary hover:bg-primary hover:text-basic transition-none cursor-crosshair">
-                <span class="font-mono text-base md:text-xl font-bold uppercase whitespace-nowrap transition-none">
-                  {item.name}
-                </span>
-                
-                <div class="dotted-leader"></div>
-                
-                <span class="font-mono text-sm md:text-lg opacity-80 text-right transition-none">
-                  {item.description}
-                </span>
-              </div>
+            <li class="group flex items-end p-4 md:p-6 border-b-2 border-primary hover:bg-primary hover:text-basic transition-none cursor-crosshair">
+              <span class="font-mono text-base md:text-xl font-bold uppercase whitespace-nowrap transition-none">
+                {item.name}
+              </span>
+              
+              <div class="dotted-leader"></div>
+              
+              <span class="font-mono text-sm md:text-lg opacity-80 text-right transition-none">
+                {item.description}
+              </span>
             </li>
           ))}
         </ul>

--- a/src/styles/theme/manga.css
+++ b/src/styles/theme/manga.css
@@ -37,3 +37,18 @@
   color: #ffffff;
   text-decoration-color: transparent;
 }
+
+.theme-manga .dotted-leader {
+  flex-grow: 1;
+  border-bottom: 3px dotted var(--color-primary);
+  margin: 0 1rem;
+  opacity: 0.4;
+  position: relative;
+  top: -0.4em; 
+  transition: none;
+}
+
+.theme-manga .group:hover .dotted-leader {
+  border-bottom-color: var(--color-basic);
+  opacity: 0.8;
+}


### PR DESCRIPTION
## What & Why
Architected a dedicated `/archive` hub to completely isolate secondary repositories and technical inventory from the main portfolio. This ensures the primary site remains strictly focused on flagship projects, while providing a scalable, highly-styled "vault" for experimental work and developer setup details.

**Resolves:** #26 

---

## Changes
- Migrated the temporary `/other-works` structure to a scalable `/archive/arsenal` route.
- Implemented `/archive/index.astro` as a minimalist "Table of Contents" entry point.
- Created `/archive/uses.astro` to serve as a technical manifest for hardware, software, and configurations.
- Refactored the data layer by extracting constants into `src/const/archive/` (`hub.ts`, `arsenal.ts`, `uses.ts`) for strict separation of concerns.
- Updated `manga.css` with `.dotted-leader` utilities to enable strict tabular formatting on the Uses page.

---

## Visuals
<!-- Screenshots, screen recordings, or "N/A" -->

---

## Checklist

- [x] Follows project architecture
- [x] UI stays minimal — no unnecessary noise
- [x] Tested locally (`bun run dev`)
- [ ] `bunx biome check` and `bunx astro check` pass