### PR TITLE
feat: improve portfolio UX, clarity, and conversion flow

### DIFF
--- a/src/components/common/CtaLink.astro
+++ b/src/components/common/CtaLink.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+	href: string
+	variant?: 'primary' | 'secondary'
+	className?: string
+}
+
+const { href, variant = 'secondary', className = '' } = Astro.props
+
+const baseClass =
+	'inline-flex min-h-10 items-center justify-center transition-colors duration-normal ease-smooth focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary'
+
+const variantClass = {
+	primary:
+		'border border-primary px-4 py-2 font-mono text-xs font-semibold uppercase tracking-widest text-primary hover:bg-primary hover:text-basic',
+	secondary:
+		'border-b border-border px-1 py-2 font-medium text-primary hover:border-secondary-hover hover:text-secondary-hover',
+}[variant]
+---
+
+<a href={href} class={`${baseClass} ${variantClass} ${className}`}>
+  <slot />
+</a>

--- a/src/components/common/CtaLink.astro
+++ b/src/components/common/CtaLink.astro
@@ -3,9 +3,15 @@ interface Props {
 	href: string
 	variant?: 'primary' | 'secondary'
 	className?: string
+	download?: boolean
 }
 
-const { href, variant = 'secondary', className = '' } = Astro.props
+const {
+	href,
+	variant = 'secondary',
+	className = '',
+	download = false,
+} = Astro.props
 
 const baseClass =
 	'inline-flex min-h-10 items-center justify-center transition-colors duration-normal ease-smooth focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary'
@@ -18,6 +24,10 @@ const variantClass = {
 }[variant]
 ---
 
-<a href={href} class={`${baseClass} ${variantClass} ${className}`}>
+<a
+  href={href}
+  class={`${baseClass} ${variantClass} ${className}`}
+  download={download ? true : undefined}
+>
   <slot />
 </a>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,12 +1,17 @@
 ---
 import AnimatedLink from '@/components/common/AnimatedLink.astro'
+import { COMMON_TEXT } from '@/const/common'
 ---
 
-<footer class="flex justify-between items-center py-8 px-6 md:px-12 lg:px-16 w-full mt-auto text-sm font-heading">
-  <div class="flex items-center gap-1.5 text-secondary">
-    <span>Typeface:</span>
+<footer class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 py-8 px-6 md:px-12 lg:px-16 w-full mt-auto text-sm font-heading">
+  <div class="flex flex-wrap items-center gap-1.5 text-secondary">
+    <span>{COMMON_TEXT.FOOTER.TYPEFACE}</span>
     <AnimatedLink href="https://fontsource.org/fonts/unbounded" text="Unbounded" />
     <span class="px-0.5">&</span>
     <AnimatedLink href="https://fontsource.org/fonts/arimo" text="Arimo" />
   </div>
+
+  <p class="text-xs uppercase tracking-widest text-secondary">
+    {COMMON_TEXT.FOOTER.BUILT_WITH}
+  </p>
 </footer>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -9,17 +9,18 @@ const navItems = [
 	{ href: '/work', label: COMMON_TEXT.NAVIGATION.WORK },
 	{ href: '/about', label: COMMON_TEXT.NAVIGATION.ABOUT },
 	{ href: '/contact', label: COMMON_TEXT.NAVIGATION.CONTACT },
+	{ href: '/resume', label: COMMON_TEXT.NAVIGATION.RESUME },
 ]
 ---
 
-<header class="flex justify-between items-center py-10 px-6 md:px-12 lg:px-16 w-full0">
+<header class="flex justify-between items-center py-8 md:py-10 px-6 md:px-12 lg:px-16 w-full">
   
-  <div class="flex items-center gap-8 md:gap-12">
+  <div class="flex items-center gap-7 md:gap-12 min-w-0">
     <a href="/" class="flex-shrink-0 text-primary hover:text-accent transition-colors duration-fast ease-smooth" aria-label="Home">
       <Logo class="h-10 md:h-12" />
     </a>
     
-    <nav class="flex gap-4 md:gap-8 text-sm font-medium text-primary">
+    <nav class="flex flex-wrap gap-x-4 gap-y-1 md:gap-x-8 text-sm font-medium text-primary">
       {navItems.map((item: { href: string; label: string }) => {
         const isActive = currentPath.startsWith(item.href);
         
@@ -27,9 +28,10 @@ const navItems = [
           <a 
             href={item.href} 
             class:list={[
-              "p-1 transition-colors duration-fast ease-smooth hover:text-accent",
-              { "text-accent": isActive } 
+              "relative p-1 transition-colors duration-fast ease-smooth hover:text-accent after:absolute after:left-1 after:right-1 after:-bottom-0.5 after:h-px after:bg-current after:transition-opacity after:duration-fast",
+              isActive ? "text-accent after:opacity-100" : "after:opacity-0" 
             ]}
+            aria-current={isActive ? 'page' : undefined}
           >
             {item.label}
           </a>

--- a/src/components/pages/about/AboutDetails.astro
+++ b/src/components/pages/about/AboutDetails.astro
@@ -2,30 +2,30 @@
 import RatioDivider from '@/components/common/RatioDivider.astro'
 import { ABOUT_TEXT } from '@/const/about'
 ---
-<section class="mt-24 xl:mt-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-12 gap-10 xl:gap-8 items-start text-sm md:text-base font-body text-secondary">
+<section class="mt-16 md:mt-20 xl:mt-28 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-12 gap-10 xl:gap-8 items-start text-base font-body text-secondary">
   
   <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8 group">
-    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-2">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-1">
       <RatioDivider />
     </div>
-    <h2 class="text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.BACKGROUND.TITLE}</h2>
-    <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.BACKGROUND.DESCRIPTION}</p>
+    <h2 class="text-primary font-mono text-xs uppercase tracking-widest">{ABOUT_TEXT.SECTIONS.BACKGROUND.TITLE}</h2>
+    <p class="leading-relaxed text-secondary/90">{ABOUT_TEXT.SECTIONS.BACKGROUND.DESCRIPTION}</p>
   </div>
 
   <div class="xl:col-span-4 flex flex-col gap-3 pr-0 md:pr-8 group">
-    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-2">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-1">
       <RatioDivider />
     </div>
-    <h2 class="text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.WORKFLOW.TITLE}</h2>
-    <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.WORKFLOW.DESCRIPTION}</p>
+    <h2 class="text-primary font-mono text-xs uppercase tracking-widest">{ABOUT_TEXT.SECTIONS.WORKFLOW.TITLE}</h2>
+    <p class="leading-relaxed text-secondary/90">{ABOUT_TEXT.SECTIONS.WORKFLOW.DESCRIPTION}</p>
   </div>
 
   <div class="xl:col-span-4 flex flex-col gap-3 xl:pl-12 group">
-    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-2">
+    <div class="w-full max-w-[120px] text-border-strong group-hover:text-secondary-hover transition-colors duration-normal mb-1">
       <RatioDivider />
     </div>
-    <h2 class="text-primary font-mono text-xs uppercase tracking-widest mb-1">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.TITLE}</h2>
-    <p class="leading-relaxed">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.DESCRIPTION}</p>
+    <h2 class="text-primary font-mono text-xs uppercase tracking-widest">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.TITLE}</h2>
+    <p class="leading-relaxed text-secondary/90">{ABOUT_TEXT.SECTIONS.OFF_SCREEN.DESCRIPTION}</p>
   </div>
 
 </section>

--- a/src/components/pages/contact/ContactHero.astro
+++ b/src/components/pages/contact/ContactHero.astro
@@ -8,6 +8,9 @@ import { CONTACT_TEXT } from '@/const/contact'
     <PageTitle>
       {CONTACT_TEXT.HERO.TITLE}
     </PageTitle>
+    <p class="mt-8 max-w-3xl text-lg md:text-xl text-primary leading-relaxed font-medium">
+      {CONTACT_TEXT.HERO.SUBTITLE}
+    </p>
     <slot />
   </div>
 </section>

--- a/src/components/pages/contact/ContactLinks.astro
+++ b/src/components/pages/contact/ContactLinks.astro
@@ -22,6 +22,6 @@ import { CONTACT_TEXT } from '@/const/contact'
 
   <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 pt-2">
     <span class="text-primary w-32 text-base md:text-lg">{CONTACT_TEXT.LABELS.RESUME}</span>
-    <AnimatedLink href="/resume" text="View Resume" icon={ArrowUpRight} />
+    <AnimatedLink href="/resume" text={CONTACT_TEXT.HERO.VIEW_RESUME} icon={ArrowUpRight} />
   </div>
 </div>

--- a/src/components/pages/contact/ContactLinks.astro
+++ b/src/components/pages/contact/ContactLinks.astro
@@ -4,24 +4,24 @@ import AnimatedLink from '@/components/common/AnimatedLink.astro'
 import { CONTACT_TEXT } from '@/const/contact'
 ---
 
-<div class="flex flex-col gap-5 text-xl md:text-2xl text-text-primary leading-normal font-medium mt-16 md:mt-24">
-  <div class="flex items-center gap-3">
-    <span class="text-text-secondary w-32">{CONTACT_TEXT.LABELS.EMAIL}</span>
+<div class="flex flex-col gap-5 text-xl md:text-2xl text-text-primary leading-normal font-medium mt-12 md:mt-16">
+  <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+    <span class="text-text-secondary w-32 text-base md:text-lg">{CONTACT_TEXT.LABELS.EMAIL}</span>
     <AnimatedLink href="mailto:an.stawski@outlook.com" text="an.stawski@outlook.com" icon={ArrowUpRight} />
   </div>
 
-  <div class="flex items-center gap-3">
-    <span class="text-text-secondary w-32">{CONTACT_TEXT.LABELS.GITHUB}</span>
+  <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+    <span class="text-text-secondary w-32 text-base md:text-lg">{CONTACT_TEXT.LABELS.GITHUB}</span>
     <AnimatedLink href="https://github.com/stkossman" text="github.com/stkossman" icon={ArrowUpRight} />
   </div>
 
-  <div class="flex items-center gap-3">
-    <span class="text-text-secondary w-32">{CONTACT_TEXT.LABELS.LINKEDIN}</span>
+  <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
+    <span class="text-text-secondary w-32 text-base md:text-lg">{CONTACT_TEXT.LABELS.LINKEDIN}</span>
     <AnimatedLink href="https://www.linkedin.com/in/andriistavskyi/" text="linkedin.com/in/andriistavskyi" icon={ArrowUpRight} />
   </div>
 
-  <div class="flex items-center gap-3">
-    <span class="text-text-secondary w-32">{CONTACT_TEXT.LABELS.RESUME}</span>
-    <AnimatedLink href="/resume" text="/resume" icon={ArrowUpRight} />
+  <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4 pt-2">
+    <span class="text-primary w-32 text-base md:text-lg">{CONTACT_TEXT.LABELS.RESUME}</span>
+    <AnimatedLink href="/resume" text="View Resume" icon={ArrowUpRight} />
   </div>
 </div>

--- a/src/components/pages/home/HeroSection.astro
+++ b/src/components/pages/home/HeroSection.astro
@@ -1,23 +1,37 @@
 ---
 import AnimatedLink from '@/components/common/AnimatedLink.astro'
+import CtaLink from '@/components/common/CtaLink.astro'
 import PageTitle from '@/components/common/PageTitle.astro'
 import { HOME_TEXT } from '@/const/home'
 ---
 
-<section class="grid grid-cols-1 xl:grid-cols-12 gap-12 xl:gap-16 items-start">
+<section class="grid grid-cols-1 xl:grid-cols-12 gap-10 xl:gap-16 items-start pb-12 md:pb-16 xl:pb-0">
   <div class="xl:col-span-9 flex flex-col gap-6 pr-0 xl:pr-12">
     <PageTitle>
       {HOME_TEXT.HERO.GREETING}
       <br />
-      {HOME_TEXT.HERO.ROLE_START} <span class="italic font-light">{HOME_TEXT.HERO.DIGITAL}</span> {HOME_TEXT.HERO.ROLE_END}
+      <span class="italic font-light">{HOME_TEXT.HERO.ROLE_START}</span>{' '}
+      {HOME_TEXT.HERO.ROLE_MIDDLE}
+      <br class="hidden sm:block" />
+      {HOME_TEXT.HERO.ROLE_END}
     </PageTitle>
     
-    <p class="max-w-3xl text-lg md:text-xl xl:text-2xl text-primary leading-normal font-medium mt-2 md:mt-4">
-      {HOME_TEXT.HERO.DESC_START} <AnimatedLink href="https://www.softserveinc.com/" text="@SoftServe" /> {HOME_TEXT.HERO.DESC_MIDDLE} <AnimatedLink href="https://www.oa.edu.ua/" text="@OstrohAcademy" /> {HOME_TEXT.HERO.DESC_END}
+    <p class="max-w-3xl text-lg md:text-xl xl:text-2xl text-primary leading-normal font-medium mt-1 md:mt-3">
+      {HOME_TEXT.HERO.DESC_START}<AnimatedLink href="https://www.softserveinc.com/" text="@SoftServe" />{HOME_TEXT.HERO.DESC_MIDDLE}
     </p>
+
+    <div class="flex flex-wrap items-center gap-4 md:gap-5 pt-4 md:pt-6">
+      <CtaLink href="/work" variant="primary">
+        {HOME_TEXT.HERO.PRIMARY_CTA}
+      </CtaLink>
+
+      <CtaLink href="/resume" variant="secondary">
+        {HOME_TEXT.HERO.SECONDARY_CTA}
+      </CtaLink>
+    </div>
   </div>
 
-  <div class="xl:col-span-3 flex justify-start xl:justify-end pt-4 xl:pt-6">
+  <div class="xl:col-span-3 flex justify-start xl:justify-end pt-0 xl:pt-6">
     <a href="https://www.softserveinc.com/" target="_blank" rel="noopener noreferrer" class="inline-block opacity-60 hover:opacity-100 transition-opacity duration-normal grayscale hover:grayscale-0">
       <img 
         src="https://assets.softserveinc.com/images/assets/hero-icon.svg/Zz1jNzMxODY4ODE2M2YxMWYxOWYyYjJlZWQ2YmU0MmQzMg==" 

--- a/src/components/pages/home/TechArchive.astro
+++ b/src/components/pages/home/TechArchive.astro
@@ -2,25 +2,26 @@
 import { HOME_TEXT } from '@/const/home'
 ---
 
-<section class="mt-24 xl:mt-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-12 gap-10 xl:gap-8 items-end text-sm md:text-base font-body  text-secondary">
-  
-  <div class="xl:col-span-4 leading-relaxed pr-0 md:pr-8">
-    {HOME_TEXT.ARCHIVE.PARAGRAPH_1}
+<section class="mt-16 md:mt-20 xl:mt-auto grid grid-cols-1 md:grid-cols-2 xl:grid-cols-12 gap-6 xl:gap-8 items-end font-mono text-xs tracking-widest uppercase text-secondary">
+  <div class="xl:col-span-5 flex flex-wrap gap-x-2 gap-y-1">
+    <span class="text-primary font-semibold">{HOME_TEXT.META.AVAILABILITY_LABEL} /</span>
+
+    {HOME_TEXT.META.AVAILABILITY.map((item, index, array) => (
+      <>
+        <span class="hover:text-primary transition-colors cursor-default">{item}</span>
+        {index < array.length - 1 && <span class="opacity-50">·</span>}
+      </>
+    ))}
   </div>
 
-  <div class="xl:col-span-4 leading-relaxed pr-0 md:pr-8">
-    {HOME_TEXT.ARCHIVE.PARAGRAPH_2}
+  <div class="xl:col-span-4 xl:col-start-9 flex flex-wrap gap-x-2 gap-y-1 xl:justify-self-end w-full md:max-w-[360px]">
+    <span class="text-primary font-semibold">{HOME_TEXT.META.STACK_LABEL} /</span>
+
+    {HOME_TEXT.STACK.map((tech, index, array) => (
+      <>
+        <span class="hover:text-primary transition-colors cursor-default">{tech}</span>
+        {index < array.length - 1 && <span class="opacity-50">·</span>}
+      </>
+    ))}
   </div>
-
-  <div class="xl:col-span-4 flex flex-wrap content-start gap-x-2 gap-y-1 font-mono text-xs tracking-widest uppercase text-secondary xl:justify-self-end mt-4 xl:mt-0 w-full md:max-w-[280px]">
-      <span class="text-primary font-semibold">Stack //</span>
-      
-      {HOME_TEXT.STACK.map((tech, index, array) => (
-        <>
-          <span class="hover:text-primary transition-colors cursor-default">{tech}</span>
-          {index < array.length - 1 && <span class="opacity-50">/</span>}
-        </>
-      ))}
-    </div>
-
 </section>

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -16,40 +16,48 @@ const projectImages = [
 	cinemadocsImg,
 ]
 ---
-<div class="flex flex-col gap-32 md:gap-[30vh] lg:gap-[50vh] mt-12 md:mt-24">
+<div class="flex flex-col gap-32 md:gap-[30vh] lg:gap-[46vh] mt-10 md:mt-20">
   {WORK_TEXT.PROJECTS.map((project: any, index: number) => (
     <section class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
 
-      <div class="lg:col-span-4 xl:col-span-3 flex flex-col gap-6 order-2 lg:order-1 sticky top-12">
+      <div class="lg:col-span-4 xl:col-span-3 flex flex-col gap-6 order-1 lg:sticky top-12">
         <h2 class="text-3xl md:text-4xl font-heading font-bold text-primary tracking-tight">
           {project.title}
         </h2>
 
-        <div class="flex flex-col gap-4 text-base md:text-lg text-secondary leading-relaxed">
-          {project.description.map((paragraph: string) => (
-            <p>{paragraph}</p>
-          ))}
-        </div>
+        <p class="text-base md:text-lg text-secondary/90 leading-relaxed">
+          {project.description}
+        </p>
 
-        <div class="flex flex-col gap-1 mt-4">
-          <span class="font-mono text-xs uppercase tracking-widest text-text-muted mb-1">{WORK_TEXT.LABELS.SCOPE_AND_ROLE}</span>
-          <span class="text-primary font-medium text-sm mb-4">{project.context} — {project.role}</span>
+        <div class="flex flex-col gap-4 mt-2 text-sm">
+          <div class="flex flex-col gap-1">
+            <span class="font-mono text-xs uppercase tracking-widest text-text-muted">{WORK_TEXT.LABELS.SCOPE_AND_ROLE}</span>
+            <span class="text-primary font-medium">{project.context} — {project.role}</span>
+          </div>
         
-          <span class="font-mono text-xs uppercase tracking-widest text-text-muted mb-1">{WORK_TEXT.LABELS.STACK_AND_LINKS}</span>
-          <span class="text-primary font-medium text-sm">{project.tech}</span>
+          <div class="flex flex-col gap-1">
+            <span class="font-mono text-xs uppercase tracking-widest text-text-muted">{WORK_TEXT.LABELS.STACK}</span>
+            <span class="text-primary font-medium">{project.tech}</span>
+          </div>
+
+          <div class="flex flex-col gap-1">
+            <span class="font-mono text-xs uppercase tracking-widest text-text-muted">{WORK_TEXT.LABELS.FOCUS}</span>
+            <span class="text-secondary/90 leading-relaxed">{project.focus}</span>
+          </div>
           
-          <div class="mt-2">
+          <div class="flex flex-col gap-1 pt-1">
+            <span class="font-mono text-xs uppercase tracking-widest text-text-muted">{WORK_TEXT.LABELS.LINKS}</span>
             <AnimatedLink href={project.link} text={COMMON_TEXT.COMPONENTS.VIEW_REPO} icon={ArrowUpRight} />
           </div>
         </div>
       </div>
 
-      <div class="project-image-container relative lg:col-span-8 xl:col-span-9 order-1 lg:order-2 w-full aspect-[4/3] md:aspect-[16/9] bg-border rounded-sm overflow-hidden group cursor-none">
+      <div class="project-image-container relative lg:col-span-8 xl:col-span-9 order-2 w-full aspect-[4/3] md:aspect-[16/9] bg-border rounded-sm overflow-hidden group cursor-none">
         <a href={project.link} target="_blank" rel="noopener noreferrer" class="block w-full h-full">
           <Image
             src={projectImages[index] as any}
             alt={`Preview of ${project.title}`}
-            class="w-full h-full object-cover grayscale opacity-90 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-slow scale-100 group-hover:scale-[1.02]"
+            class="w-full h-full object-contain grayscale opacity-90 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-slow scale-100 group-hover:scale-[1.01]"
           />
         </a>
 
@@ -59,8 +67,8 @@ const projectImages = [
       </div>
     </section>
   ))}
-  <section class="flex flex-col items-center justify-center text-center mt-12 md:mt-32 pb-24 border-t border-border pt-24">
-    <h3 class="text-secondary font-mono text-xs uppercase tracking-widest mb-6">
+  <section class="flex flex-col items-center justify-center text-center mt-4 md:mt-24 pb-24 border-t border-border pt-16 md:pt-20">
+    <h3 class="max-w-sm text-secondary font-mono text-xs uppercase tracking-widest leading-relaxed mb-6">
       {WORK_TEXT.FOOTER.TITLE}
     </h3>
     <AnimatedLink href={WORK_TEXT.FOOTER.HREF} text={WORK_TEXT.FOOTER.LINK_TEXT} />

--- a/src/components/pages/work/ProjectList.astro
+++ b/src/components/pages/work/ProjectList.astro
@@ -17,7 +17,7 @@ const projectImages = [
 ]
 ---
 <div class="flex flex-col gap-32 md:gap-[30vh] lg:gap-[46vh] mt-10 md:mt-20">
-  {WORK_TEXT.PROJECTS.map((project: any, index: number) => (
+  {WORK_TEXT.PROJECTS.map((project, index) => (
     <section class="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-16 items-start">
 
       <div class="lg:col-span-4 xl:col-span-3 flex flex-col gap-6 order-1 lg:sticky top-12">
@@ -55,7 +55,7 @@ const projectImages = [
       <div class="project-image-container relative lg:col-span-8 xl:col-span-9 order-2 w-full aspect-[4/3] md:aspect-[16/9] bg-border rounded-sm overflow-hidden group cursor-none">
         <a href={project.link} target="_blank" rel="noopener noreferrer" class="block w-full h-full">
           <Image
-            src={projectImages[index] as any}
+            src={projectImages[index]!}
             alt={`Preview of ${project.title}`}
             class="w-full h-full object-contain grayscale opacity-90 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-slow scale-100 group-hover:scale-[1.01]"
           />

--- a/src/components/pages/work/WorkHero.astro
+++ b/src/components/pages/work/WorkHero.astro
@@ -3,7 +3,7 @@ import PageTitle from '@/components/common/PageTitle.astro'
 import { WORK_TEXT } from '@/const/work'
 ---
 
-<section class="min-h-[70vh] flex flex-col justify-center grid grid-cols-1 xl:grid-cols-12 gap-8 items-start mt-8 md:mt-0">
+<section class="min-h-[64vh] md:min-h-[66vh] flex flex-col justify-center grid grid-cols-1 xl:grid-cols-12 gap-8 items-start mt-8 md:mt-0">
   <div class="xl:col-span-11 flex flex-col pr-0">
     <PageTitle>
       {WORK_TEXT.HERO.TITLE}

--- a/src/const/about.ts
+++ b/src/const/about.ts
@@ -7,17 +7,17 @@ export const ABOUT_TEXT = {
 		BACKGROUND: {
 			TITLE: 'Background',
 			DESCRIPTION:
-				"I'm studying Computer Science at Ostroh Academy, have completed a .NET/React internship at SoftServe, and am actively looking for work. I hold a B2 First (FCE) Cambridge certification, which allows me to comfortably consume documentation and collaborate without language barriers.",
+				"I'm studying Computer Science at Ostroh Academy and recently completed a .NET/React internship at SoftServe. I'm currently open to junior frontend/full-stack opportunities and comfortable working with English documentation and international teams.",
 		},
 		WORKFLOW: {
 			TITLE: 'Workflow',
 			DESCRIPTION:
-				'My development environment reflects my design philosophy: highly functional and stripped of bloat. I run a keyboard-centric workflow relying on Vim, customized Linux distributions like Fedora, and the Hyprland tiling window manager to keep my workspace structured.',
+				'I prefer focused, keyboard-driven workflows and lightweight tools that help me stay productive. My setup is intentionally minimal, structured, and optimized for fast iteration.',
 		},
 		OFF_SCREEN: {
 			TITLE: 'Off-Screen',
 			DESCRIPTION:
-				"When I'm not writing code, I'm drawn to the atmosphere and challenge of Dark Fantasy—immersing myself in worlds like Dark Souls, Elden Ring, and Berserk. I also have a deep interest in Indian culture and spend time watching Bollywood films.",
+				"Outside code, I'm drawn to dark fantasy, Souls-like worlds, Indian culture, and films - references that often shape my visual taste and atmosphere.",
 		},
 	},
 } as const

--- a/src/const/common.ts
+++ b/src/const/common.ts
@@ -3,9 +3,11 @@ export const COMMON_TEXT = {
 		WORK: 'Work',
 		ABOUT: 'About',
 		CONTACT: 'Contact',
+		RESUME: 'Resume',
 	},
 	FOOTER: {
 		TYPEFACE: 'Typeface:',
+		BUILT_WITH: `© ${new Date().getFullYear()} Andrii Stavskyi`,
 	},
 	COMPONENTS: {
 		CLOCK_COUNTRY: 'Ukraine',

--- a/src/const/contact.ts
+++ b/src/const/contact.ts
@@ -1,7 +1,9 @@
 export const CONTACT_TEXT = {
 	HERO: {
 		TITLE:
-			"Feel free to reach out! I'm always happy to chat about new projects, ideas, or just say hi",
+			"Let's build something clean. I'm open to new opportunities and collaborations.",
+		SUBTITLE:
+			'Currently open to junior frontend/full-stack roles, freelance projects, and meaningful product work.',
 	},
 	LABELS: {
 		EMAIL: 'Email',

--- a/src/const/contact.ts
+++ b/src/const/contact.ts
@@ -4,6 +4,7 @@ export const CONTACT_TEXT = {
 			"Let's build something clean. I'm open to new opportunities and collaborations.",
 		SUBTITLE:
 			'Currently open to junior frontend/full-stack roles, freelance projects, and meaningful product work.',
+		VIEW_RESUME: 'View Resume',
 	},
 	LABELS: {
 		EMAIL: 'Email',

--- a/src/const/home.ts
+++ b/src/const/home.ts
@@ -1,13 +1,15 @@
 export const HOME_TEXT = {
 	HERO: {
 		GREETING: "Hello, I'm Andrii,",
-		ROLE_START: 'Developer. Please welcome to my',
-		DIGITAL: 'digital',
-		ROLE_END: 'space.',
-		DESC_START: 'Completed a .NET/React internship ',
+		ROLE_START: 'Frontend-focused',
+		ROLE_MIDDLE: 'Developer',
+		ROLE_END: 'building clean digital products.',
+		DESC_START:
+			'React, TypeScript, Astro and .NET developer. Completed a .NET/React internship at ',
 		DESC_MIDDLE:
-			', now actively looking for work and studying Computer Science at ',
-		DESC_END: '.',
+			' and currently open to junior frontend/full-stack opportunities.',
+		PRIMARY_CTA: 'View Work',
+		SECONDARY_CTA: 'View Resume',
 	},
 	ARCHIVE: {
 		PARAGRAPH_1:
@@ -15,14 +17,10 @@ export const HOME_TEXT = {
 		PARAGRAPH_2:
 			"My approach centers around minimalism and clarity. I enjoy crafting experiences that respect the user's attention, combining clean aesthetics with robust functionality.",
 	},
-	STACK: [
-		'C#',
-		'Node.js',
-		'React',
-		'Astro',
-		'Tailwind',
-		'PostgreSQL',
-		'MySQL',
-		'Prisma',
-	],
+	STACK: ['React', 'TypeScript', 'Astro', '.NET'],
+	META: {
+		AVAILABILITY_LABEL: 'Open to work',
+		AVAILABILITY: ['Frontend', 'Full-stack', 'Remote'],
+		STACK_LABEL: 'Stack',
+	},
 } as const

--- a/src/const/resume.ts
+++ b/src/const/resume.ts
@@ -17,7 +17,7 @@ export const RESUME_TEXT = {
 		SUMMARY: {
 			TITLE: 'Summary',
 			CONTENT:
-				'Frontend-oriented Full-Stack Developer dedicated to building robust, minimalist web applications and high-performance tooling. Proficient in architecting complex systems using React, TypeScript, and .NET, with hands-on experience implementing real-time synchronization (SignalR), local-first storage (IndexedDB), and Feature-Sliced Design. Experienced in delivering end-to-end features - from clean, reusable UI components to secure backend administrative modules. Passionate about developer experience (DX) and modern, fast runtimes.',
+				'Frontend-oriented Full-Stack Developer with hands-on experience building React, TypeScript, Astro and .NET applications. Completed a .NET/React internship at SoftServe, working on admin modules, validation-heavy forms, and backend operations. Focused on clean UI, maintainable architecture, and fast developer experience.',
 		},
 		EXPERIENCE: {
 			TITLE: 'Experience',
@@ -41,16 +41,25 @@ export const RESUME_TEXT = {
 			location: 'Remote',
 			role: 'Full-Stack Developer Intern (Completed)',
 			period: 'Mar 2026 - Jun 2026',
-			description:
-				"Took ownership of the 'Home' and 'Company Profile' administrative modules for the Victory Center project, delivering features across the entire stack. Designed backend endpoints using C# and .NET 9, leveraging CQRS/MediatR for clean separation of commands and queries. Implemented frontend solutions in React and TypeScript, handling complex state synchronization and form validation. Successfully resolved architectural and merge conflicts, refining project configurations to optimize the development workflow. Currently actively looking for work.",
+			bullets: [
+				'Took ownership of Home and Company Profile admin modules for the Victory Center project.',
+				'Built full-stack features across React, TypeScript, C#, and .NET 9.',
+				'Designed backend endpoints using CQRS/MediatR patterns.',
+				'Implemented validation-heavy frontend forms and handled complex state flows.',
+				'Resolved merge/configuration conflicts and improved development workflow.',
+			],
 		},
 		{
 			company: 'National University "Ostroh Academy"',
 			location: '',
 			role: 'Frontend Developer (University Practice)',
 			period: 'Jan 2026 - Feb 2026',
-			description:
-				'Led frontend development for a Cinema Management SPA using React and TypeScript, integrating with an ASP.NET Core API. Engineered a real-time seat selection component and an interactive cinema hall builder. Implemented secure authentication and protected routes within the client application. Acted as Team Lead, managing Git Flow, conducting code reviews, and distributing tasks.',
+			bullets: [
+				'Led frontend development for a Cinema Management SPA using React and TypeScript.',
+				'Integrated the frontend with an ASP.NET Core API.',
+				'Built real-time seat selection and an interactive cinema hall builder.',
+				'Managed Git Flow, code reviews, and task distribution as Team Lead.',
+			],
 		},
 	],
 	EDUCATION: {
@@ -62,13 +71,13 @@ export const RESUME_TEXT = {
 			name: 'Soliloquy',
 			stack: 'Astro, React, Dexie.js, Bun',
 			description:
-				'Developed a privacy-centric, serverless note-taking application designed with a familiar messenger-style user interface. Engineered a 100% local-first data layer utilizing IndexedDB for instant load times and data ownership. Built an optimized frontend architecture using Astro/React on the Bun runtime.',
+				'Built a privacy-focused, local-first note app with a messenger-style interface and IndexedDB persistence for fast, serverless data ownership.',
 		},
 		{
 			name: 'Winup',
 			stack: 'TypeScript, Bun, CLI',
 			description:
-				'Created a fast, interactive command-line wrapper for managing Windows package upgrades (winget) without visual noise. Implemented a safe-by-default upgrade flow.',
+				'Created a fast CLI wrapper for Windows package upgrades with an interactive, safe-by-default winget workflow.',
 		},
 	],
 	SKILLS: [

--- a/src/const/work.ts
+++ b/src/const/work.ts
@@ -1,11 +1,13 @@
 export const WORK_TEXT = {
 	HERO: {
 		TITLE:
-			"A few projects I'm building. Turning complex problems into clean, functional, and minimal software.",
+			'Selected work in React, .NET, and local-first web apps. Clean interfaces, focused architecture, and practical systems.',
 	},
 	LABELS: {
 		SCOPE_AND_ROLE: 'Scope & Role',
-		STACK_AND_LINKS: 'Stack & Links',
+		STACK: 'Stack',
+		FOCUS: 'Technical Focus',
+		LINKS: 'Links',
 	},
 	PROJECTS: [
 		{
@@ -13,10 +15,10 @@ export const WORK_TEXT = {
 			title: 'Soliloquy',
 			context: 'Personal Project',
 			role: 'Full-stack Developer',
-			description: [
-				'A local-first reimagining of "Saved Messages", designed as a private messenger where the only contact is you.',
-				'Engineered for absolute privacy and performance. It leverages IndexedDB (via Dexie.js) for zero-cloud data persistence, wrapped in a highly reactive Astro and React architecture.',
-			],
+			description:
+				'A private, local-first notes app inspired by messenger interfaces, where the user is the only contact.',
+			focus:
+				'Built zero-cloud persistence with IndexedDB and Dexie.js, pairing Astro with React for a fast, minimal writing experience.',
 			tech: 'Astro, React, TypeScript, TailwindCSS, Dexie.js',
 			link: 'https://github.com/stkossman/soliloquy',
 		},
@@ -25,10 +27,10 @@ export const WORK_TEXT = {
 			title: 'Victory Center Platform',
 			context: 'Internship / SoftServe',
 			role: 'Full-stack Developer',
-			description: [
-				'A comprehensive full-stack management system developed as part of the SoftServe IT Academy. The platform handles dynamic content management, team profiles, and donation processing.',
-				'Engineered transactional Admin operations using .NET 9 with CQRS and MediatR patterns. On the client side, I developed key administrative modules in React and resolved intricate form validation edge-cases to ensure a robust user experience.',
-			],
+			description:
+				'A full-stack management platform for content, team profiles, and donation-related workflows, developed during the SoftServe IT Academy.',
+			focus:
+				'Implemented admin-facing modules in React and supported transactional .NET 9 operations using CQRS and MediatR patterns.',
 			tech: 'C# (.NET 9), React, TypeScript, MediatR, MS SQL',
 			link: 'https://github.com/ita-social-projects/VictoryCenter-Back',
 		},
@@ -37,10 +39,10 @@ export const WORK_TEXT = {
 			title: 'Cinema Platform - Frontend',
 			context: 'Commercial / Practice',
 			role: 'Frontend Developer',
-			description: [
-				'A comprehensive web client for a Cinema Management System, strictly structured around the Feature-Sliced Design (FSD) architectural pattern.',
-				'Implements real-time WebSocket synchronization via SignalR for live seat-locking, complex server state management with TanStack Query, and an immersive modern UI.',
-			],
+			description:
+				'A cinema management web client structured around Feature-Sliced Design for a modular, maintainable frontend.',
+			focus:
+				'Integrated SignalR seat-lock synchronization and TanStack Query server state flows for responsive booking interactions.',
 			tech: 'React, TypeScript, TailwindCSS, SignalR, TanStack Query',
 			link: 'https://github.com/ModusTeam/cinema-platform-front',
 		},
@@ -49,17 +51,17 @@ export const WORK_TEXT = {
 			title: 'Cinema Platform - Documentation',
 			context: 'Commercial / Practice',
 			role: 'Technical Writer',
-			description: [
-				'The centralized developer hub and single source of truth for the Cinema Platform ecosystem.',
-				'Built with Astro Starlight, featuring an automated integration that parses remote OpenAPI (swagger.json) specifications to generate interactive REST API references alongside architectural guides.',
-			],
+			description:
+				'A centralized developer documentation hub for the Cinema Platform ecosystem, built as a practical source of truth.',
+			focus:
+				'Used Astro Starlight and OpenAPI parsing to generate interactive REST references alongside architecture guides.',
 			tech: 'Astro Starlight, OpenAPI, TailwindCSS',
 			link: 'https://github.com/ModusTeam/cinema-platform-docs',
 		},
 	],
 	FOOTER: {
-		TITLE: 'Looking for experimental repositories?',
-		LINK_TEXT: '[ Access Arsenal ]',
+		TITLE: 'Smaller experiments and repositories live in the archive.',
+		LINK_TEXT: 'Access Arsenal',
 		HREF: '/archive',
 	},
 } as const

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,4 +1,5 @@
 ---
+import CtaLink from '@/components/common/CtaLink.astro'
 import { RESUME_TEXT } from '@/const/resume'
 import Layout from '@/layouts/Layout.astro'
 
@@ -16,8 +17,8 @@ const {
 ---
 
 <Layout title={META.TITLE}>
-  <article class="w-full max-w-3xl mx-auto py-20 md:py-28">
-    <header class="mb-16 md:mb-24">
+  <article class="w-full max-w-3xl mx-auto py-16 md:py-24">
+    <header class="mb-14 md:mb-20">
       <div class="flex flex-col gap-8 md:flex-row md:items-start md:justify-between">
         <div>
           <p class="text-sm md:text-base text-text-secondary mb-4">{HEADER.ROLE}</p>
@@ -26,16 +27,17 @@ const {
           </h1>
         </div>
 
-        <a
+        <CtaLink
           href="/resume.pdf"
-          download
-          class="inline-flex w-fit items-center text-sm md:text-base font-medium text-primary border-b border-border hover:border-secondary-hover"
+          variant="primary"
+          download={true}
+          className="w-fit"
         >
           {HEADER.DOWNLOAD}
-        </a>
+        </CtaLink>
       </div>
 
-      <div class="mt-10 flex flex-col gap-2 text-base md:text-lg text-text-secondary leading-relaxed">
+      <div class="mt-8 flex flex-col gap-2 text-base md:text-lg text-text-secondary leading-relaxed">
         <p>{HEADER.CONTACT_INFO}</p>
         <nav aria-label={META.TITLE} class="flex flex-wrap gap-x-5 gap-y-2">
           {LINKS.map((link) => (
@@ -47,37 +49,41 @@ const {
       </div>
     </header>
 
-    <div class="flex flex-col gap-16 md:gap-20">
+    <div class="flex flex-col gap-12 md:gap-16">
       <section aria-labelledby="summary">
-        <h2 id="summary" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
+        <h2 id="summary" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-5">
           {SECTIONS.SUMMARY.TITLE}
         </h2>
-        <p class="text-xl md:text-2xl leading-relaxed text-primary">
+        <p class="text-lg md:text-xl leading-relaxed text-primary">
           {SECTIONS.SUMMARY.CONTENT}
         </p>
       </section>
 
       <section aria-labelledby="experience">
-        <h2 id="experience" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-8">
+        <h2 id="experience" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
           {SECTIONS.EXPERIENCE.TITLE}
         </h2>
-        <ul class="flex flex-col gap-10">
+        <ul class="flex flex-col gap-9">
           {EXPERIENCE.map((item) => (
             <li>
-              <div class="flex flex-col gap-1 mb-4">
+              <div class="flex flex-col gap-1 mb-3">
                 <h3 class="text-xl md:text-2xl font-heading font-medium">{item.company}</h3>
                 <p class="text-text-secondary leading-relaxed">
                   {[item.location, item.role, item.period].filter(Boolean).join(' | ')}
                 </p>
               </div>
-              <p class="text-lg leading-relaxed text-primary">{item.description}</p>
+              <ul class="flex list-disc flex-col gap-2 pl-5 text-base md:text-lg leading-relaxed text-primary">
+                {item.bullets.map((bullet) => (
+                  <li>{bullet}</li>
+                ))}
+              </ul>
             </li>
           ))}
         </ul>
       </section>
 
       <section aria-labelledby="education">
-        <h2 id="education" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
+        <h2 id="education" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-5">
           {SECTIONS.EDUCATION.TITLE}
         </h2>
         <div class="flex flex-col gap-1">
@@ -89,29 +95,29 @@ const {
       </section>
 
       <section aria-labelledby="projects">
-        <h2 id="projects" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-8">
+        <h2 id="projects" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
           {SECTIONS.PROJECTS.TITLE}
         </h2>
-        <ul class="flex flex-col gap-8">
+        <ul class="flex flex-col gap-7">
           {PROJECTS.map((project) => (
             <li>
-              <h3 class="text-xl md:text-2xl font-heading font-medium mb-3">
+              <h3 class="text-xl md:text-2xl font-heading font-medium mb-2">
                 {project.name}
                 <span class="text-text-secondary"> ({project.stack})</span>
               </h3>
-              <p class="text-lg leading-relaxed text-primary">{project.description}</p>
+              <p class="text-base md:text-lg leading-relaxed text-primary">{project.description}</p>
             </li>
           ))}
         </ul>
       </section>
 
       <section aria-labelledby="skills">
-        <h2 id="skills" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-8">
+        <h2 id="skills" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
           {SECTIONS.SKILLS.TITLE}
         </h2>
-        <ul class="flex flex-col gap-5">
+        <ul class="flex flex-col gap-4">
           {SKILLS.map((skill) => (
-            <li class="text-lg leading-relaxed">
+            <li class="text-base md:text-lg leading-relaxed">
               <strong class="font-medium text-primary">{skill.label}:</strong>
               <span class="text-text-secondary"> {skill.value}</span>
             </li>
@@ -120,10 +126,10 @@ const {
       </section>
 
       <section aria-labelledby="certifications">
-        <h2 id="certifications" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-8">
+        <h2 id="certifications" class="text-sm font-heading uppercase tracking-normal text-text-secondary mb-6">
           {SECTIONS.CERTIFICATIONS.TITLE}
         </h2>
-        <ul class="flex list-disc flex-col gap-3 pl-5 text-lg leading-relaxed text-primary">
+        <ul class="flex list-disc flex-col gap-2 pl-5 text-base md:text-lg leading-relaxed text-primary">
           {CERTIFICATIONS.map((item) => (
             <li>{item}</li>
           ))}


### PR DESCRIPTION
## What & Why
Refines the portfolio’s key pages to make the experience clearer, more recruiter-friendly, and more conversion-oriented while preserving the existing minimalist/editorial visual identity.


**Resolves:** #43 

---

## Changes
* Updated homepage Hero copy, CTA behavior, and compact meta information.
* Added reusable `CtaLink` component for consistent minimal CTA styling.
* Improved About page copy, spacing, and readability.
* Refined Work page intro, project copy structure, screenshot framing, and archive CTA.
* Improved Contact page headline, supporting copy, and contact link hierarchy.
* Added Resume to the header navigation and improved active nav state.
* Balanced footer with a subtle build note while preserving the typeface credit.
* Reworked Resume page summary, experience, projects, skills, spacing, and PDF CTA.

---

## Visuals
N/A

---

## Checklist

- [x] Follows project architecture
- [x] UI stays minimal — no unnecessary noise
- [x] Tested locally (`bun run dev`)
- [x] `bunx biome check` and `bunx astro check` pass